### PR TITLE
Installed lodash as npm dependency to fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "intl-tel-input": "^10.0.2",
     "jquery": "3.1.1",
     "json2csv": "^3.7.1",
+    "lodash": "^4.17.4",
     "method-override": "2.3.6",
     "moment": "2.15.2",
     "moment-range": "2.2.0",


### PR DESCRIPTION
Upon running the app, the Cannot find module 'lodash' error would come up.
![missing_lodash](https://cloud.githubusercontent.com/assets/215220/24368031/8e3f6d26-12e4-11e7-8273-5a61571790d5.png)
![missing_lodash2](https://cloud.githubusercontent.com/assets/215220/24368036/901b32ce-12e4-11e7-9bb1-d7597b943e24.png)
