### PR TITLE
Remove auth cred from CourseComponent link

### DIFF
--- a/src/js/components/CourseComponent.js
+++ b/src/js/components/CourseComponent.js
@@ -55,6 +55,17 @@ module.exports = React.createBackboneClass({
     this.getModel().save();
   },
 
+  getTextbook(event, props) {
+    event.preventDefault();
+    const { is_admin, is_instructor, is_student } = props.currentUser.attributes
+    if (is_admin || is_instructor) {
+      location.assign(`${this.getModel().get('textbook').get('instructor_url')}`)
+    }
+    if (is_student) {
+      location.assign(`${this.getModel().get('textbook').get('student_url')}`)
+    }
+  },
+
   addHoliday(e) {
     e.preventDefault();
     const holidays = this.getModel().get('holidays').splice(0);
@@ -379,7 +390,7 @@ module.exports = React.createBackboneClass({
               </a>
               <a
                 className="btn btn-default"
-                href={this.getModel().get('textbook').get('instructor_url')}
+                onClick={e => this.getTextbook(e, this.props)}
                 target="_blank"
               >
                 <FontAwesome name="book" />


### PR DESCRIPTION
Fetches appropriate textbook url by reading Client auth level from `props`.

- [x] Auth credentials no longer appear in the `href`
- [x] Browser history remains consistent (after clicking the link, the browser's back button will perform as expected)

Note that this will only work if the `instructor_url` and `student_url` are stored in a full form within the respective `'textbook'` document (with the proper `http://` prefix) - e.g. `http://google.com`. If the entry instead reads `google.com`, it will simply append that entry to the current `window.location` - and subsequently redirect to a non-existent path (`http://localhost:3000/google.com`).
