### PR TITLE
added 'use strict' where appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ reports
 faviconData.json
 views/favicon-*
 *.sqlite3
+notes

--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var express = require('express');
 var app = express();
 

--- a/controllers/GradeController.js
+++ b/controllers/GradeController.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const UserModel = require('../models/UserModel');
 
 /**

--- a/routes/report.js
+++ b/routes/report.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var express = require('express');
 var router = express.Router();
 var ReportController = require('../controllers/ReportController.js');

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('underscore');
 const Hashids = require('hashids');
 const hashids = new Hashids();


### PR DESCRIPTION
(Ubuntu)
Attempted to use gulp within the campus-manager directory; encountered errors requiring 'use strict' be used when variables were declared with 'let'.