### PR TITLE
First pass at dockerizing campus manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Pull base image.
+FROM ubuntu:14.04
+
+# Install debug tools
+RUN \
+  sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list && \
+  apt-get update && \
+  apt-get -y upgrade && \
+  apt-get install -y build-essential && \
+  apt-get install -y software-properties-common && \
+  apt-get install -y byobu curl git htop man unzip vim wget && \
+# Install Python.
+  apt-get install -y python python-dev python-pip python-virtualenv && \
+# Install Java.
+  apt-get install -y openjdk-7-jdk && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install NodeJS
+RUN \
+  curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash - && \
+  sudo apt-get install -y nodejs
+
+# Define commonly used JAVA_HOME variable
+ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+
+WORKDIR /usr/src/app
+COPY package.json .
+RUN npm install
+
+# Bundle app source
+COPY . .
+RUN npm rebuild && npm run favicon && npm run gulp build
+CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '2'
+
+services:
+  manager:
+    image: austincoding/campusmanager:1.0.0
+    build:
+      context: .
+    ports:
+      - "3000:3000"
+    env_file:
+      - ./.env
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo:latest


### PR DESCRIPTION
Hi there!

This is a trivial first pass at dockerizing the campus manager. 

## Testing steps

1. Install docker and docker-compose
2. Check out my branch

Update the `.env` file to have

```
MONGOLAB_URI=mongodb://mongo/campus-manager-dev 
```

Build the image and bring up the container via

    $ docker-compose up --build -d

Navigate to http://localhost:3000 in your browser.

## Notes

This basic dockerization uses an ephemeral mongodb instance, but the env file can point to any mongodb instance you'd like. We could probably create a dev/prod version of the docker-compose file. Feedback appreciated.
