### PR TITLE
Replace require with import in react components

### DIFF
--- a/src/js/components/AppsModalComponent.js
+++ b/src/js/components/AppsModalComponent.js
@@ -3,7 +3,7 @@ import {
   Modal, Button, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox,
   InputGroup, Alert
 } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
+import FontAwesome from 'react-fontawesome';
 
 module.exports = React.createBackboneClass({
   render() {

--- a/src/js/components/BaseModal.js
+++ b/src/js/components/BaseModal.js
@@ -1,6 +1,6 @@
-var React = require('react');
-var Modal = require('react-modal');
-var _ = require('underscore');
+import React from 'react';
+import Modal from 'react-modal';
+import _ from 'underscore';
 
 module.exports = React.createBackboneClass({
   render: function() {

--- a/src/js/components/CourseAttendanceComponent.js
+++ b/src/js/components/CourseAttendanceComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Line} from 'react-chartjs';
-const Chart = require('chart.heatmap.js');
+import Chart from 'chart.heatmap.js';
 import { Row, Col, Panel } from 'react-bootstrap';
 
 module.exports = React.createBackboneClass({

--- a/src/js/components/CourseComponent.js
+++ b/src/js/components/CourseComponent.js
@@ -1,18 +1,18 @@
 import * as _ from 'underscore';
 import * as React from 'react';
-const moment = require('moment');
-var BaseModal = require('./BaseModal');
-var CourseVideoUpload = require('./CourseVideoUpload');
-const CourseAttendanceComponent = require('./CourseAttendanceComponent');
-const utils = require('../utils');
+import moment from 'moment';
+import BaseModal from './BaseModal';
+import CourseVideoUpload from './CourseVideoUpload';
+import CourseAttendanceComponent from './CourseAttendanceComponent';
+import utils from '../utils';
 import {
   Col, Row, Button, ButtonGroup, Table, FormControl, FormGroup,
   ControlLabel, Panel, Checkbox, ListGroup, ListGroupItem, InputGroup
 } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const DatePicker = require('react-datepicker');
-const GradeModel = require('../models/GradeModel');
-const CourseUserComponent = require('./CourseUserComponent');
+import FontAwesome from 'react-fontawesome';
+import DatePicker from 'react-datepicker';
+import GradeModel from '../models/GradeModel';
+import CourseUserComponent from './CourseUserComponent';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/CourseModalComponent.js
+++ b/src/js/components/CourseModalComponent.js
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import {
-  Modal, Button, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox,
-  InputGroup, Alert
-} from 'react-bootstrap';
-const Select = require('react-select');
-const TermOptionComponent = require('./TermOptionComponent');
-const TermValueComponent = require('./TermValueComponent');
-const LocationOptionComponent = require('./LocationOptionComponent');
-const LocationValueComponent = require('./LocationValueComponent');
-const LocationModel = require('../models/LocationModel');
-const TermModel = require('../models/TermModel');
-const TextbookModel = require('../models/TextbookModel');
-const CourseModel = require('../models/CourseModel');
+  Modal, Button, Row,
+  Col, FormGroup, ControlLabel,
+  FormControl, Checkbox, InputGroup,
+  Alert } from 'react-bootstrap';
+import Select from 'react-select';
+import TermOptionComponent from './TermOptionComponent';
+import TermValueComponent from './TermValueComponent';
+import LocationOptionComponent from './LocationOptionComponent';
+import LocationValueComponent from './LocationValueComponent';
+import LocationModel from '../models/LocationModel';
+import TermModel from '../models/TermModel';
+import TextbookModel from '../models/TextbookModel';
+import CourseModel from '../models/CourseModel';
 
 module.exports = React.createBackboneClass({
   mixins: [

--- a/src/js/components/CourseOptionComponent.js
+++ b/src/js/components/CourseOptionComponent.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Label } from 'react-bootstrap';
-const moment = require('moment');
+import moment from 'moment';
 
 module.exports = React.createClass({
 	handleMouseDown (event) {

--- a/src/js/components/CourseUserComponent.js
+++ b/src/js/components/CourseUserComponent.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as _ from 'underscore';
-const utils = require('../utils');
+import utils from '../utils';
 import { Checkbox } from 'react-bootstrap';
-const moment = require('moment');
-const DatePicker = require('react-datepicker');
+import moment from 'moment';
+import DatePicker from 'react-datepicker';
 
 module.exports = React.createBackboneClass({
   mixins: [

--- a/src/js/components/CourseVideoUpload.js
+++ b/src/js/components/CourseVideoUpload.js
@@ -3,8 +3,8 @@ import {
   Modal, Button, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox,
   InputGroup, Alert
 } from 'react-bootstrap';
-const YoutubeAccountSelect = require('./YoutubeAccountSelect');
-const YoutubeUploader = require('./YoutubeUploader');
+import YoutubeAccountSelect from './YoutubeAccountSelect';
+import YoutubeUploader from './YoutubeUploader';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/CoursesListComponent.js
+++ b/src/js/components/CoursesListComponent.js
@@ -2,11 +2,11 @@ import * as React from 'react';
 import * as Backbone from 'backbone';
 import { Table, Tr, Td, Th, Thead } from 'reactable';
 import { Col, Row, Button, FormControl } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const CourseModalComponent = require('./CourseModalComponent.js');
-const CourseModel = require('../models/CourseModel');
-const TermsCollection = require('../collections/TermsCollection');
-const moment = require('moment');
+import FontAwesome from 'react-fontawesome';
+import CourseModalComponent from './CourseModalComponent.js';
+import CourseModel from '../models/CourseModel';
+import TermsCollection from '../collections/TermsCollection';
+import moment from 'moment';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/HomeLayoutComponent.js
+++ b/src/js/components/HomeLayoutComponent.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 var TermCardComponent = React.createFactory(require('./TermCardComponent'));
 
 module.exports = React.createBackboneClass({

--- a/src/js/components/LocationModalComponent.js
+++ b/src/js/components/LocationModalComponent.js
@@ -4,7 +4,7 @@ import {
   InputGroup, Alert
 } from 'react-bootstrap';
 import ReactPhoneInput from 'react-phone-input';
-const LocationModel = require('../models/LocationModel');
+import LocationModel from '../models/LocationModel';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/LocationOptionComponent.js
+++ b/src/js/components/LocationOptionComponent.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 	handleMouseDown (event) {

--- a/src/js/components/LocationValueComponent.js
+++ b/src/js/components/LocationValueComponent.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 	render () {

--- a/src/js/components/LocationsListComponent.js
+++ b/src/js/components/LocationsListComponent.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Table, Tr, Td, Th, Thead } from 'reactable';
 import { Col, Row, Button, FormControl } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const LocationModalComponent = require('./LocationModalComponent');
-const LocationModel = require('../models/LocationModel');
+import FontAwesome from 'react-fontawesome';
+import LocationModalComponent from './LocationModalComponent';
+import LocationModel from '../models/LocationModel';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/NavbarComponent.js
+++ b/src/js/components/NavbarComponent.js
@@ -3,9 +3,9 @@ import * as _ from 'underscore';
 import {
   Navbar, Nav, NavItem, NavDropdown, MenuItem, Button, Label
 } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const AppsModalComponent = require('./AppsModalComponent');
-const FeedbackModalComponent = require('./FeedbackModalComponent');
+import FontAwesome from 'react-fontawesome';
+import AppsModalComponent from './AppsModalComponent';
+import FeedbackModalComponent from './FeedbackModalComponent';
 
 module.exports = React.createBackboneClass({
   links: {

--- a/src/js/components/RegistrationModalComponent.js
+++ b/src/js/components/RegistrationModalComponent.js
@@ -4,13 +4,13 @@ import {
   Modal, Button, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox,
   InputGroup, Alert
 } from 'react-bootstrap';
-const Select = require('react-select');
-const UserOptionComponent = require('./UserOptionComponent');
-const UserValueComponent = require('./UserValueComponent');
-const CourseOptionComponent = require('./CourseOptionComponent');
-const CourseValueComponent = require('./CourseValueComponent');
-const UserModel = require('../models/UserModel');
-const CourseModel = require('../models/CourseModel');
+import Select from 'react-select';
+import UserOptionComponent from './UserOptionComponent';
+import UserValueComponent from './UserValueComponent';
+import CourseOptionComponent from './CourseOptionComponent';
+import CourseValueComponent from './CourseValueComponent';
+import UserModel from '../models/UserModel';
+import CourseModel from '../models/CourseModel';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/RegistrationsListComponent.js
+++ b/src/js/components/RegistrationsListComponent.js
@@ -2,8 +2,8 @@ import * as React from 'react';
 import * as Backbone from 'backbone';
 import { Table, Tr, Td, Th, Thead } from 'reactable';
 import { Col, Row, Button, FormControl } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const RegistrationModalComponent = require('./RegistrationModalComponent');
+import FontAwesome from 'react-fontawesome';
+import RegistrationModalComponent from './RegistrationModalComponent';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/ReportComponent.js
+++ b/src/js/components/ReportComponent.js
@@ -1,15 +1,15 @@
 import * as Backbone from 'backbone';
 import * as React from 'react';
-const CodeMirror = require('react-codemirror');
+import CodeMirror from 'react-codemirror';
 import 'cm-sql';
-const Clipboard = require('clipboard');
-const utils = require('../utils');
+import Clipboard from 'clipboard';
+import utils from '../utils';
 import { Table } from 'reactable';
 import {
   Col, Row, Button, FormControl, ButtonGroup, OverlayTrigger, Tooltip, Tabs,
   Tab, DropdownButton, MenuItem
 } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
+import FontAwesome from 'react-fontawesome';
 
 module.exports = React.createBackboneClass({
   mixins: [

--- a/src/js/components/StripeCheckoutComponent.js
+++ b/src/js/components/StripeCheckoutComponent.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as Backbone from 'backbone';
 import StripeCheckout from 'react-stripe-checkout';
 import { Button } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
+import FontAwesome from 'react-fontawesome';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/TermCardComponent.js
+++ b/src/js/components/TermCardComponent.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createBackboneClass({
   render: function() {

--- a/src/js/components/TermModalComponent.js
+++ b/src/js/components/TermModalComponent.js
@@ -3,9 +3,9 @@ import {
   Modal, Button, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox,
   InputGroup, Alert
 } from 'react-bootstrap';
-const DatePicker = require('react-datepicker');
-const TermModel = require('../models/TermModel');
-const moment = require('moment');
+import DatePicker from 'react-datepicker';
+import TermModel from '../models/TermModel';
+import moment from 'moment';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/TermOptionComponent.js
+++ b/src/js/components/TermOptionComponent.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-const moment = require('moment');
+import moment from 'moment';
 
 module.exports = React.createClass({
 	handleMouseDown (event) {

--- a/src/js/components/TermValueComponent.js
+++ b/src/js/components/TermValueComponent.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-const moment = require('moment');
+import moment from 'moment';
 
 module.exports = React.createClass({
 	render () {

--- a/src/js/components/TermsListComponent.js
+++ b/src/js/components/TermsListComponent.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Table, Tr, Td, Th, Thead } from 'reactable';
 import { Col, Row, Button, FormControl } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const TermModalComponent = require('./TermModalComponent.js');
-const TermModel = require('../models/TermModel');
-const moment = require('moment');
+import FontAwesome from 'react-fontawesome';
+import TermModalComponent from './TermModalComponent.js';
+import TermModel from '../models/TermModel';
+import moment from 'moment';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/TextbookModalComponent.js
+++ b/src/js/components/TextbookModalComponent.js
@@ -3,7 +3,7 @@ import {
   Modal, Button, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox,
   InputGroup, Alert
 } from 'react-bootstrap';
-const TextbookModel = require('../models/TextbookModel');
+import TextbookModel from '../models/TextbookModel';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/TextbooksListComponent.js
+++ b/src/js/components/TextbooksListComponent.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Table, Tr, Td, Th, Thead } from 'reactable';
 import { Col, Row, Button, FormControl } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const TextbookModalComponent = require('./TextbookModalComponent');
-const TextbookModel = require('../models/TextbookModel');
+import FontAwesome from 'react-fontawesome';
+import TextbookModalComponent from './TextbookModalComponent';
+import TextbookModel from '../models/TextbookModel';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/TrackModalComponent.js
+++ b/src/js/components/TrackModalComponent.js
@@ -3,11 +3,11 @@ import {
   Modal, Button, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox,
   InputGroup, Alert
 } from 'react-bootstrap';
-const Select = require('react-select');
+import Select from 'react-select';
 import ReactPhoneInput from 'react-phone-input';
-const TrackModel = require('../models/TrackModel');
-const CourseOptionComponent = require('./CourseOptionComponent');
-const CourseValueComponent = require('./CourseValueComponent');
+import TrackModel from '../models/TrackModel';
+import CourseOptionComponent from './CourseOptionComponent';
+import CourseValueComponent from './CourseValueComponent';
 
 module.exports = React.createBackboneClass({
   mixins: [

--- a/src/js/components/TracksListComponent.js
+++ b/src/js/components/TracksListComponent.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Table, Tr, Td, Th, Thead } from 'reactable';
 import { Col, Row, Button, FormControl } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const TrackModalComponent = require('./TrackModalComponent');
-const TrackModel = require('../models/TrackModel');
+import FontAwesome from 'react-fontawesome';
+import TrackModalComponent from './TrackModalComponent';
+import TrackModel from '../models/TrackModel';
 import { Sparklines, SparklinesLine } from 'react-sparklines';
 
 module.exports = React.createBackboneClass({

--- a/src/js/components/UserAccountComponent.js
+++ b/src/js/components/UserAccountComponent.js
@@ -1,17 +1,17 @@
 import * as React from 'react';
 import * as _ from 'underscore';
-const moment = require('moment');
-const StripeCheckoutComponent = require('./StripeCheckoutComponent');
+import moment from 'moment';
+import StripeCheckoutComponent from './StripeCheckoutComponent';
 import {
   Row, Col, Panel, Table, FormGroup, InputGroup, FormControl, ControlLabel,
   Tabs, Tab
 } from 'react-bootstrap';
-const Select = require('react-select');
-const CourseOptionComponent = require('./CourseOptionComponent');
-const CourseValueComponent = require('./CourseValueComponent');
-const CourseModel = require('../models/CourseModel');
-const CoursesCollection = require('../collections/CoursesCollection');
-const utils = require('../utils');
+import Select from 'react-select';
+import CourseOptionComponent from './CourseOptionComponent';
+import CourseValueComponent from './CourseValueComponent';
+import CourseModel from '../models/CourseModel';
+import CoursesCollection from '../collections/CoursesCollection';
+import utils from '../utils';
 
 module.exports = React.createBackboneClass({
   mixins: [

--- a/src/js/components/UserComponent.js
+++ b/src/js/components/UserComponent.js
@@ -1,23 +1,23 @@
 import * as _ from 'underscore';
 import * as React from 'react';
 import * as Backbone from 'backbone';
-const moment = require('moment');
+import moment from 'moment';
 import { Doughnut } from 'react-chartjs';
 import {
   Col, Row, Panel, PanelGroup, Table, Well, ControlLabel, FormControl,
   InputGroup, Button
 } from 'react-bootstrap';
-const Gravatar = require('react-gravatar');
+import Gravatar from 'react-gravatar';
 import Equalizer from 'react-equalizer';
-const FontAwesome = require('react-fontawesome');
-const TermsCollection = require('../collections/TermsCollection');
-const UserAccountComponent = require('./UserAccountComponent');
-const UserModalComponent = require('./UserModalComponent');
-const UserReviewComponent = require('./UserReviewComponent');
-const GradeModel = require('../models/GradeModel');
-const reviews = require('../data/reviews');
-const socials = require('../data/social');
-const utils = require('../utils');
+import FontAwesome from 'react-fontawesome';
+import TermsCollection from '../collections/TermsCollection';
+import UserAccountComponent from './UserAccountComponent';
+import UserModalComponent from './UserModalComponent';
+import UserReviewComponent from './UserReviewComponent';
+import GradeModel from '../models/GradeModel';
+import reviews from '../data/reviews';
+import socials from '../data/social';
+import utils from '../utils';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/UserModalComponent.js
+++ b/src/js/components/UserModalComponent.js
@@ -4,10 +4,10 @@ import {
   Modal, Button, Row, Col, FormGroup, ControlLabel, FormControl, Checkbox,
   InputGroup, Alert
 } from 'react-bootstrap';
-const Select = require('react-select');
+import Select from 'react-select';
 import ReactPhoneInput from 'react-phone-input';
-const UserModel = require('../models/UserModel');
-const LocationsCollection = require('../collections/LocationsCollection');
+import UserModel from '../models/UserModel';
+import LocationsCollection from '../collections/LocationsCollection';
 
 module.exports = React.createBackboneClass({
   roleOptions: [

--- a/src/js/components/UserOptionComponent.js
+++ b/src/js/components/UserOptionComponent.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 	handleMouseDown (event) {

--- a/src/js/components/UserReviewComponent.js
+++ b/src/js/components/UserReviewComponent.js
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import { Row, Col, Panel, ListGroup, ListGroupItem, ProgressBar } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const reviews = require('../data/reviews');
-const socials = require('../data/social');
-const utils = require('../utils');
+import FontAwesome from 'react-fontawesome';
+import reviews from '../data/reviews';
+import socials from '../data/social';
+import utils from '../utils';
 
 module.exports = React.createBackboneClass({
   handleReviewClick(e) {

--- a/src/js/components/UserValueComponent.js
+++ b/src/js/components/UserValueComponent.js
@@ -1,4 +1,4 @@
-var React = require('react');
+import React from 'react';
 
 module.exports = React.createClass({
 	render () {

--- a/src/js/components/UsersListComponent.js
+++ b/src/js/components/UsersListComponent.js
@@ -2,9 +2,9 @@ import * as Backbone from 'backbone';
 import * as React from 'react';
 import { Table, Tr, Td, Th, Thead } from 'reactable';
 import { Col, Row, Button, FormControl } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
-const UserModalComponent = require('./UserModalComponent');
-const UserModel = require('../models/UserModel');
+import FontAwesome from 'react-fontawesome';
+import UserModalComponent from './UserModalComponent';
+import UserModel from '../models/UserModel';
 
 module.exports = React.createBackboneClass({
   getInitialState() {

--- a/src/js/components/YoutubeUploader.js
+++ b/src/js/components/YoutubeUploader.js
@@ -1,10 +1,10 @@
 import * as React from 'react';
-const Dropzone = require('react-dropzone');
-const moment = require('moment');
-const MediaUploader = require('../modules/MediaUploader');
-const DatePicker = require('react-datepicker');
+import Dropzone from 'react-dropzone';
+import moment from 'moment';
+import MediaUploader from '../modules/MediaUploader';
+import DatePicker from 'react-datepicker';
 import { Row, Col, FormGroup, ControlLabel } from 'react-bootstrap';
-const FontAwesome = require('react-fontawesome');
+import FontAwesome from 'react-fontawesome';
 
 module.exports = React.createBackboneClass({
   getInitialState: function() {


### PR DESCRIPTION
When developing locally, opening a create user/course/textbook/etc throws the following error:
<img width="1273" alt="error on modal open" src="https://user-images.githubusercontent.com/25089304/40287229-835f8742-5c71-11e8-8799-698970339ff3.png">
Has to do with using both `require` and `import` at the same time, also causes CircleCI tests to fail.